### PR TITLE
Actually respect the "--with-chisel" option

### DIFF
--- a/configure
+++ b/configure
@@ -564,6 +564,7 @@ PACKAGE_URL=''
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 chiseldir
+chisel_version
 OBJEXT
 EXEEXT
 ac_ct_CXX
@@ -2229,6 +2230,13 @@ if test "${with_chisel+set}" = set; then :
   withval=$with_chisel;
 fi
 
+
+if test "x$with_chisel" != "x"; then :
+  chisel_version=latest.release
+
+      chisel_version=latest.SNAPSHOT
+
+fi
 
 chiseldir=$with_chisel
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,15 +1,13 @@
 AC_INIT(sodor, 1.0)
 
-if [[ "$RISCV" == "" ]]
-then
-  echo 'The $RISCV environment variable must be set!'
-  exit 1
-fi
-
 AC_PROG_CXX
 
 # Chisel/Scala sources
 AC_ARG_WITH(chisel, [  --with-chisel           path to chisel sources])
+
+AS_IF([test "x$with_chisel" != "x"],
+      [AC_SUBST(chisel_version, latest.release)]
+      [AC_SUBST(chisel_version, latest.SNAPSHOT)])
 
 AC_SUBST(chiseldir, $with_chisel)
 
@@ -20,4 +18,3 @@ AC_OUTPUT(
     project/build.properties
     project/build.scala
 )
-

--- a/project/build.scala.in
+++ b/project/build.scala.in
@@ -5,7 +5,7 @@ object BuildSettings extends Build {
   val buildOrganization = "berkeley"
   val buildVersion = "2.0"
   val buildScalaVersion = "2.10.2"
-  val chiselVersion = System.getProperty("chiselVersion", "latest.release")
+  val chiselVersion = System.getProperty("chiselVersion", "@chisel_version@")
 
   val buildSettings = Defaults.defaultSettings ++ Seq (
     organization := buildOrganization,


### PR DESCRIPTION
It turns out that you need to modify the build.scala in order to make
SBT actually use the local versions of Chisel.  The current autoconf
stuff wasn't doing that, which means that despite the fact that Chisel
was being built it wasn't actually being used.

This is still sub-optimal: it globally installs the Chisel version
you're using for Sodor.  I know nothing of SBT, so I'm just not going
to touch that... :).
