### PR TITLE
Updates to stay compatible with new auto CloneType.

### DIFF
--- a/src/common/debug.scala
+++ b/src/common/debug.scala
@@ -83,7 +83,7 @@ class SimDTM(implicit val conf: SodorConfiguration) extends BlackBox {
   }
 }
 
-class DebugDPath(implicit conf: SodorConfiguration) extends Bundle
+class DebugDPath(implicit val conf: SodorConfiguration) extends Bundle
 {
   // REG access
   val addr = Output(UInt(5.W))
@@ -93,12 +93,12 @@ class DebugDPath(implicit conf: SodorConfiguration) extends Bundle
   val resetpc = Output(Bool())
 }
 
-class DebugCPath(implicit conf: SodorConfiguration) extends Bundle
+class DebugCPath(implicit val conf: SodorConfiguration) extends Bundle
 {
   val halt = Output(Bool())
 }
 
-class DebugIo(implicit conf: SodorConfiguration) extends Bundle
+class DebugIo(implicit val conf: SodorConfiguration) extends Bundle
 {
   val dmi = Flipped(new DMIIO())
   val ddpath = new DebugDPath()


### PR DESCRIPTION
Add `val` qualifier to Bundle arguments so parameter is immutable and available during auto-cloning.

This avoids the
```
[error] (run-main-0) chisel3.internal.ChiselException: Unable to automatically infer cloneType on Common.DebugDPath@434: constructor has parameters Set(conf) that are not both immutable and accessible. Either make all parameters immutable and accessible (vals) so cloneType can be inferred, or define a custom cloneType method.
```
when built with current chisel3 releases.
