### PR TITLE
Invalidateapi

### DIFF
--- a/project/build.properties.in
+++ b/project/build.properties.in
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.16

--- a/src/common/csr.scala
+++ b/src/common/csr.scala
@@ -155,6 +155,7 @@ class CSRFileIO(implicit conf: SodorConfiguration) extends Bundle {
 class CSRFile(implicit conf: SodorConfiguration) extends Module
 {
   val io = IO(new CSRFileIO)
+  io := DontCare
 
   val reset_mstatus = Wire(init=new MStatus().fromBits(0))
   reset_mstatus.mpp := PRV.M

--- a/src/common/debug.scala
+++ b/src/common/debug.scala
@@ -109,16 +109,18 @@ class DebugIo(implicit conf: SodorConfiguration) extends Bundle
 
 class DebugModule(implicit val conf: SodorConfiguration) extends Module {
   val io = IO(new DebugIo())
-  
+  io := DontCare
 
   io.dmi.req.ready := io.dmi.req.valid
   val dmireq = io.dmi.req.valid
   io.dmi.resp.bits.resp := DMConsts.dmi_RESP_SUCCESS
   val dmstatusReset  = Wire(new DMSTATUSFields())
+  dmstatusReset := DontCare
   dmstatusReset.authenticated := true.B
   dmstatusReset.versionlo := "b10".U
   val dmstatus = Reg(init = dmstatusReset)
   val sbcsreset = Wire(new SBCSFields())
+  sbcsreset := DontCare
   sbcsreset.sbaccess := 2.U
   sbcsreset.sbasize := 32.U
   sbcsreset.sbaccess32 := true.B
@@ -126,6 +128,7 @@ class DebugModule(implicit val conf: SodorConfiguration) extends Module {
   sbcsreset.sbaccess8 := false.B
   val sbcs = Reg(init = sbcsreset)
   val abstractcsReset = Wire(new ABSTRACTCSFields())
+  abstractcsReset := DontCare
   abstractcsReset.datacount := DMConsts.nDataCount.U
   abstractcsReset.progsize := DMConsts.nProgBuf.U
   val abstractcs = Reg(init = abstractcsReset)

--- a/src/rv32_1stage/core.scala
+++ b/src/rv32_1stage/core.scala
@@ -33,6 +33,7 @@ class CoreIo(implicit conf: SodorConfiguration) extends Bundle
 class Core(implicit conf: SodorConfiguration) extends Module
 {
   val io = IO(new CoreIo())
+  io := DontCare
   val c  = Module(new CtlPath())
   val d  = Module(new DatPath())
   c.io.ctl  <> d.io.ctl

--- a/src/rv32_1stage/cpath.scala
+++ b/src/rv32_1stage/cpath.scala
@@ -41,9 +41,10 @@ class CpathIo(implicit conf: SodorConfiguration) extends Bundle()
                                                                                                                             
 class CtlPath(implicit conf: SodorConfiguration) extends Module
 {                                                                                                                   
-  val io = IO(new CpathIo())                                                                                            
-                                                                                                                    
-   val csignals =                                                                                                   
+  val io = IO(new CpathIo())
+  io := DontCare
+
+   val csignals =
       ListLookup(io.dat.inst,                                                                                       
                              List(N, BR_N  , OP1_X  ,  OP2_X  , ALU_X   , WB_X   , REN_0, MEN_0, M_X  , MT_X,  CSR.N),
                Array(       /* val  |  BR  |  op1   |   op2     |  ALU    |  wb  | rf   | mem  | mem  | mask |  csr  */

--- a/src/rv32_1stage/dpath.scala
+++ b/src/rv32_1stage/dpath.scala
@@ -38,7 +38,8 @@ class DpathIo(implicit conf: SodorConfiguration) extends Bundle()
 class DatPath(implicit conf: SodorConfiguration) extends Module
 {
    val io = IO(new DpathIo())
-      
+   io := DontCare
+
    // Instruction Fetch
    val pc_next          = Wire(UInt(32.W))
    val pc_plus4         = Wire(UInt(32.W))
@@ -154,6 +155,7 @@ class DatPath(implicit conf: SodorConfiguration) extends Module
 
    // Control Status Registers
    val csr = Module(new CSRFile())
+   csr.io := DontCare
    csr.io.decode.csr := inst(CSR_ADDR_MSB,CSR_ADDR_LSB)
    csr.io.rw.cmd   := io.ctl.csr_cmd 
    csr.io.rw.wdata := alu_out

--- a/src/rv32_1stage/tile.scala
+++ b/src/rv32_1stage/tile.scala
@@ -24,6 +24,7 @@ class SodorTile(implicit val conf: SodorConfiguration) extends Module
    // alive so that the HTIF can load in the program.
    val debug = Module(new DebugModule())
    val core   = Module(new Core())
+   core.io := DontCare
    val memory = Module(new AsyncScratchPadMemory(num_core_ports = 2))
    core.io.dmem <> memory.io.core_ports(0)
    core.io.imem <> memory.io.core_ports(1)

--- a/src/rv32_2stage/cpath.scala
+++ b/src/rv32_2stage/cpath.scala
@@ -43,6 +43,7 @@ class CpathIo(implicit conf: SodorConfiguration) extends Bundle()
 class CtlPath(implicit conf: SodorConfiguration) extends Module
 {
   val io = IO(new CpathIo())
+  io := DontCare
 
    val csignals =
       ListLookup(io.dat.inst,

--- a/src/rv32_2stage/dpath.scala
+++ b/src/rv32_2stage/dpath.scala
@@ -38,7 +38,8 @@ class DpathIo(implicit conf: SodorConfiguration) extends Bundle()
 class DatPath(implicit conf: SodorConfiguration) extends Module
 {
    val io = IO(new DpathIo())
-   
+   io := DontCare
+
    //**********************************
    // Pipeline State Registers
    val if_reg_pc = Reg(init = START_ADDR) 
@@ -177,6 +178,7 @@ class DatPath(implicit conf: SodorConfiguration) extends Module
 
    // Control Status Registers
    val csr = Module(new CSRFile())
+   csr.io := DontCare
    csr.io.decode.csr  := exe_reg_inst(CSR_ADDR_MSB,CSR_ADDR_LSB)
    csr.io.rw.cmd   := io.ctl.csr_cmd
    csr.io.rw.wdata := exe_alu_out

--- a/src/rv32_2stage/tile.scala
+++ b/src/rv32_2stage/tile.scala
@@ -20,6 +20,7 @@ class SodorTile(implicit val conf: SodorConfiguration) extends Module
    })
    
    val core   = Module(new Core())
+   core.io := DontCare
    val memory = Module(new AsyncScratchPadMemory(num_core_ports = 2))
    val debug = Module(new DebugModule())
 

--- a/src/rv32_3stage/cpath.scala
+++ b/src/rv32_3stage/cpath.scala
@@ -31,7 +31,7 @@ class CtrlSignals extends Bundle()
    val csr_cmd   = Output(UInt(CSR.SZ)) 
 
    val dmem_val  = Output(Bool())
-   val dmem_fcn  = Output(UInt(M_X.getWidth))
+   val dmem_fcn  = Output(UInt(M_X.getWidth.W))
    val dmem_typ  = Output(UInt(3.W))
  
    val exception = Output(Bool())   
@@ -51,7 +51,8 @@ class CpathIo(implicit conf: SodorConfiguration) extends Bundle()
 class CtlPath(implicit conf: SodorConfiguration) extends Module
 {
    val io = IO(new CpathIo())
-                             //                                     
+   io := DontCare
+                             //
                              //   inst val?                                                                                mem flush/sync
                              //   |    br type                      alu fcn                 bypassable?                    |
                              //   |    |     is jmp?                |        wb sel         |  mem en               csr cmd|

--- a/src/rv32_3stage/dpath.scala
+++ b/src/rv32_3stage/dpath.scala
@@ -44,6 +44,7 @@ class DpathIo(implicit conf: SodorConfiguration) extends Bundle()
 class DatPath(implicit conf: SodorConfiguration) extends Module 
 {
    val io = IO(new DpathIo())
+   io := DontCare
 
 
    //**********************************
@@ -213,6 +214,7 @@ class DatPath(implicit conf: SodorConfiguration) extends Module
     
    // Control Status Registers
    val csr = Module(new CSRFile())
+   csr.io := DontCare
    csr.io.decode.csr   := wb_reg_csr_addr
    csr.io.rw.wdata  := wb_reg_alu
    csr.io.rw.cmd    := wb_reg_ctrl.csr_cmd 

--- a/src/rv32_3stage/frontend.scala
+++ b/src/rv32_3stage/frontend.scala
@@ -80,7 +80,7 @@ class FrontEndCpuIO(implicit conf: SodorConfiguration) extends Bundle
 class FrontEnd(implicit conf: SodorConfiguration) extends Module
 {
    val io = IO(new FrontEndIO)
-
+   io := DontCare
 
    //**********************************
    // Pipeline State Registers

--- a/src/rv32_3stage/tile.scala
+++ b/src/rv32_3stage/tile.scala
@@ -34,7 +34,8 @@ class SodorTile(implicit val conf: SodorConfiguration) extends Module
    })
 
    val core   = Module(new Core())
-   val memory = Module(new SyncScratchPadMemory(num_core_ports = NUM_MEMORY_PORTS)) 
+   core.io := DontCare
+   val memory = Module(new SyncScratchPadMemory(num_core_ports = NUM_MEMORY_PORTS))
    val debug = Module(new DebugModule())
    core.reset := debug.io.resetcore | reset.toBool
 

--- a/src/rv32_5stage/cpath.scala
+++ b/src/rv32_5stage/cpath.scala
@@ -58,6 +58,7 @@ class CpathIo(implicit conf: SodorConfiguration) extends Bundle()
 class CtlPath(implicit conf: SodorConfiguration) extends Module
 {
   val io = IO(new CpathIo())
+  io := DontCare
 
    val csignals =
       ListLookup(io.dat.dec_inst,

--- a/src/rv32_5stage/dpath.scala
+++ b/src/rv32_5stage/dpath.scala
@@ -43,6 +43,7 @@ class DpathIo(implicit conf: SodorConfiguration) extends Bundle()
 class DatPath(implicit conf: SodorConfiguration) extends Module
 {
    val io = IO(new DpathIo())
+   io := DontCare
 
    //**********************************
    // Pipeline State Registers
@@ -353,6 +354,7 @@ class DatPath(implicit conf: SodorConfiguration) extends Module
    // Control Status Registers
    // The CSRFile can redirect the PC so it's easiest to put this in Execute for now.
    val csr = Module(new CSRFile())
+   csr.io := DontCare
    csr.io.decode.csr  := mem_reg_inst(CSR_ADDR_MSB,CSR_ADDR_LSB)
    csr.io.rw.wdata := mem_reg_alu_out
    csr.io.rw.cmd   := mem_reg_ctrl_csr_cmd

--- a/src/rv32_5stage/tile.scala
+++ b/src/rv32_5stage/tile.scala
@@ -21,6 +21,7 @@ class SodorTile(implicit val conf: SodorConfiguration) extends Module
    })
    
    val core   = Module(new Core())
+   core.io := DontCare
    val memory = Module(new AsyncScratchPadMemory(num_core_ports = 2))
    val debug = Module(new DebugModule())
 

--- a/src/rv32_ucode/cpath.scala
+++ b/src/rv32_ucode/cpath.scala
@@ -52,6 +52,7 @@ class CpathIo(implicit conf: SodorConfiguration) extends Bundle()
 class CtlPath(implicit conf: SodorConfiguration) extends Module
 {
    val io = IO(new CpathIo())
+  io := DontCare
 
    // Compile the Micro-code down into a ROM 
   val (label_target_map, label_sz) = MicrocodeCompiler.constructLabelTargetMap(Microcode.codes)

--- a/src/rv32_ucode/dpath.scala
+++ b/src/rv32_ucode/dpath.scala
@@ -38,6 +38,7 @@ class DpathIo(implicit conf: SodorConfiguration) extends Bundle()
 class DatPath(implicit conf: SodorConfiguration) extends Module
 {
    val io = IO(new DpathIo())
+   io := DontCare
 
 
    // forward declarations
@@ -135,6 +136,7 @@ class DatPath(implicit conf: SodorConfiguration) extends Module
    
    // Control Status Registers
    val csr = Module(new CSRFile())
+   csr.io := DontCare
    csr.io.decode.csr  := csr_addr
    csr.io.rw.wdata := csr_wdata
    csr.io.rw.cmd   := io.ctl.csr_cmd


### PR DESCRIPTION
Update sbt build version to 0.13.16
Use `DontCare`s to avoid "not completely initialized" errors from current firrtl releases.
