### PR TITLE
Update trace infrastructure

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,20 +50,25 @@ debug:
 console:
 	$(SBT) "project ${MK_TARGET_PROC}" console
 
-run-emulator: $(patsubst %,emulator/%/generated-src/timestamp,$(targets))
+timestamps := $(foreach x,$(targets),emulator/$(x)/generated-src/timestamp)
+timestamps_debug := $(foreach x,$(targets),emulator/$(x)/generated-src-debug/timestamp)
 
-run-emulator-debug: $(patsubst %,emulator/%/generated-src-debug/timestamp,$(targets))
+run-emulator: $(timestamps)
+
+run-emulator-debug: $(timestamps_debug)
 
 clean-tests:
 	for d in $(addprefix emulator/,$(all_targets)) ; do \
 		$(MAKE) -C "$${d}" clean-tests ; \
 	done
+	$(RM) $(timestamps) $(timestamps_debug)
 
 clean:
 	-find sbt -type d -name target -exec rm -rf {} \+
 	for d in $(addprefix emulator/,$(all_targets)) ; do \
-		$(MAKE) -C $$d clean ; \
+		$(MAKE) -C "$${d}" clean ; \
 	done
+	$(RM) $(timestamps) $(timestamps_debug)
 	$(RM) test-results.xml
 
 reports: test-results.xml report-cpi report-bp report-stats

--- a/emulator/common/Makefile.include
+++ b/emulator/common/Makefile.include
@@ -13,11 +13,13 @@ ELF         := elf2hex
 
 # pipe processor output through the spike-dasm program to turn 
 # raw instruction bits into pretty, readable diassembly
-disasm_exe := 2>
+tracer := $(common)/tracer.py
+disasm_exe := 3>&1 1>&2 2>&3 | $(tracer)
 which_disasm := $(shell which spike-dasm)
 ifneq ($(which_disasm),)
-disasm_exe := 3>&1 1>&2 2>&3 | $(which_disasm) $(DISASM_EXTENSION) >
+disasm_exe := $(disasm_exe) | $(which_disasm) $(DISASM_EXTENSION)
 endif
+disasm_exe := $(disasm_exe) >
  
 
 MODEL := Top
@@ -209,7 +211,7 @@ output:
 output/%.vcd: $(global_tstdir)/% emulator-debug | output
 	./emulator-debug -v$@ +max-cycles=$(asm_test_timeout) $< 2> /dev/null
 
-output/%.out: $(global_tstdir)/% emulator | output
+output/%.out: $(global_tstdir)/% emulator $(tracer) | output
 	./emulator +max-cycles=$(asm_test_timeout) $< $(disasm_exe) $@
 #	-./emulator +max-cycles=$(asm_test_timeout) $(seed) +verbose +coremap-random +loadmem=$< none $(disasm_exe) $(patsubst %.out,%.temp,$@)
 #	sed -e '/@@@/ !d' -e 's/-.*//g' -e 's/@@@ //' <$(patsubst %.out,%.temp,$@) >$(patsubst %.out,%.commit,$@)
@@ -226,7 +228,7 @@ output/%.vpd: output/%.hex emulator-debug | output
 
 ifeq ($(SUPERVISOR_MODE),"false")
  
-$(addprefix output/, $(global_bmarks_out)): output/%.riscv.out: $(global_bmarkdir)/%.riscv emulator | output
+$(addprefix output/, $(global_bmarks_out)): output/%.riscv.out: $(global_bmarkdir)/%.riscv emulator $(tracer) | output
 	./emulator +max-cycles=$(bmark_timeout) +verbose $< $(disasm_exe) $@
 $(addprefix output/, $(global_bmarks_vcd)): output/%.riscv.vcd: $(global_bmarkdir)/%.riscv emulator-debug | output
 	./emulator-debug -v$@ +max-cycles=$(bmark_timeout) +verbose $< 2> /dev/null

--- a/emulator/common/tracer.py
+++ b/emulator/common/tracer.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+import sys
+import re
+
+# Match on committed instructions
+INST_RE = re.compile(r"[^\[]*\[1\].*DASM\(([0-9A-Fa-f]+)\)")
+
+class Tracer:
+    # Initialize your new counters to 0 here
+    def __init__(self):
+        self.inst_count = 0
+        self.nop_count = 0
+        self.bubble_count = 0
+        self.misc_count = 0
+        self.br_count = 0
+        self.ldst_count = 0
+        self.arith_count = 0
+        self.cycles = 0
+
+    # Increment your counters as appropriate here
+    def retire(self, inst):
+        opcode = inst & 0x7f
+        opc_hi = (opcode >> 5) & 0x3
+        opc_lo = (opcode >> 2) & 0x7
+
+        self.inst_count += 1
+
+        if inst == 0x13:
+            self.nop_count += 1
+        elif opcode == 0x37:
+            self.misc_count += 1
+        elif opcode == 0x63:
+            self.br_count += 1
+        elif opcode == 0x03 or opcode == 0x23:
+            self.ldst_count += 1
+        elif opc_lo == 0x6 or opc_lo == 0x4:
+            self.arith_count += 1
+        else:
+            self.misc_count += 1
+
+        self.cycles += 1
+
+    def bubble(self):
+        self.bubble_count += 1
+        self.cycles += 1
+
+    # Print your new counts here
+    def print_results(self):
+        print("#----------Stats--------------")
+        print("#")
+        print("#   CPI    : {:2.2f}".format(float(self.cycles) / self.inst_count))
+        print("#   IPC    : {:2.2f}".format(float(self.inst_count) / self.cycles))
+        print("#   cycles : {}".format(self.cycles))
+        print("#")
+        print("#   Bubbles      : {:2.3f} %".format(float(self.bubble_count) / self.cycles * 100))
+        print("#   Nop instr    : {:2.3f} %".format(float(self.nop_count) / self.cycles * 100))
+        print("#   Arith instr  : {:2.3f} %".format(float(self.arith_count) / self.cycles * 100))
+        print("#   Ld/St instr  : {:2.3f} %".format(float(self.ldst_count) / self.cycles * 100))
+        print("#   branch instr : {:2.3f} %".format(float(self.br_count) / self.cycles * 100))
+        print("#   misc instr   : {:2.3f} %".format(float(self.misc_count) / self.cycles * 100))
+
+def main():
+    tracer = Tracer()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if line.startswith('Cyc='):
+            m = INST_RE.match(line)
+            if m:
+                inst = int(m.group(1), 16)
+                tracer.retire(inst)
+            else:
+                tracer.bubble()
+        print(line)
+
+    tracer.print_results()
+
+if __name__ == "__main__":
+    main()

--- a/src/rv32_1stage/dpath.scala
+++ b/src/rv32_1stage/dpath.scala
@@ -161,7 +161,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    csr.io.rw.cmd   := io.ctl.csr_cmd
    csr.io.rw.wdata := alu_out
 
-   csr.io.retire    := !io.ctl.stall
+   csr.io.retire    := !(io.ctl.stall || io.ctl.exception)
    csr.io.exception := io.ctl.exception
    csr.io.pc        := pc_reg
    exception_target := csr.io.evec

--- a/src/rv32_1stage/dpath.scala
+++ b/src/rv32_1stage/dpath.scala
@@ -78,11 +78,12 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    val wb_addr  = inst(RD_MSB,  RD_LSB)
 
    val wb_data = Wire(UInt(conf.xprlen.W))
+   val wb_wen = io.ctl.rf_wen && !io.ctl.exception
 
    // Register File
    val regfile = Mem(32, UInt(conf.xprlen.W))
 
-   when (io.ctl.rf_wen && (wb_addr =/= 0.U) && !io.ctl.exception)
+   when (wb_wen && (wb_addr =/= 0.U))
    {
       regfile(wb_addr) := wb_data
    }
@@ -193,26 +194,28 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    // Printout
    // pass output through the spike-dasm binary (found in riscv-tools) to turn
    // the DASM(%x) into a disassembly string.
-   printf("Cyc= %d Op1=[0x%x] Op2=[0x%x] W[%c,%d= 0x%x] %c Mem[%d: R:0x%x W:0x%x] PC= 0x%x %c%c DASM(%x)\n"
-      , csr.io.time(31,0)
-      , alu_op1
-      , alu_op2
-      , Mux(io.ctl.rf_wen, Str("W"), Str("_"))
-      , wb_addr
-      , wb_data
-      , Mux(csr.io.exception, Str("E"), Str(" ")) // EXC -> E
-      , io.ctl.wb_sel
-      , io.dmem.resp.bits.data
-      , io.dmem.req.bits.data
-      , pc_reg
-      , Mux(io.ctl.stall, Str("s"), Str(" "))
-      , Mux(io.ctl.pc_sel  === 1.U, Str("B"),
-         Mux(io.ctl.pc_sel === 2.U, Str("J"),
-         Mux(io.ctl.pc_sel === 3.U, Str("K"),// JR -> K
-         Mux(io.ctl.pc_sel === 4.U, Str("X"),// EX -> X
-         Mux(io.ctl.pc_sel === 0.U, Str(" "), Str("?"))))))
-      , inst
-      )
+   printf("Cyc= %d [%d] pc=[%x] W[r%d=%x][%d] Op1=[r%d][%x] Op2=[r%d][%x] inst=[%x] %c%c%c DASM(%x)\n",
+      csr.io.time(31,0),
+      csr.io.retire,
+      pc_reg,
+      wb_addr,
+      wb_data,
+      wb_wen,
+      rs1_addr,
+      alu_op1,
+      rs2_addr,
+      alu_op2,
+      inst,
+      Mux(io.ctl.stall, Str("S"), Str(" ")),
+      MuxLookup(io.ctl.pc_sel, Str("?"), Seq(
+         PC_BR -> Str("B"),
+         PC_J -> Str("J"),
+         PC_JR -> Str("R"),
+         PC_EXC -> Str("E"),
+         PC_4 -> Str(" "))),
+      Mux(csr.io.exception, Str("X"), Str(" ")),
+      inst)
+
 
    if (PRINT_COMMIT_LOG)
    {

--- a/src/rv32_2stage/dpath.scala
+++ b/src/rv32_2stage/dpath.scala
@@ -47,6 +47,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    val exe_reg_pc       = RegInit(0.asUInt(conf.xprlen.W))
    val exe_reg_pc_plus4 = RegInit(0.asUInt(conf.xprlen.W))
    val exe_reg_inst     = RegInit(BUBBLE)
+   val exe_reg_valid    = RegInit(false.B)
 
    //**********************************
    // Instruction Fetch Stage
@@ -84,11 +85,13 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    {
       exe_reg_inst := BUBBLE
       exe_reg_pc   := 0.U
+      exe_reg_valid := false.B
    }
    .otherwise
    {
       exe_reg_inst := if_inst
       exe_reg_pc   := if_reg_pc
+      exe_reg_valid := true.B
    }
 
    exe_reg_pc_plus4 := if_pc_plus4
@@ -185,7 +188,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    csr.io.rw.wdata := exe_alu_out
    val csr_out = csr.io.rw.rdata
 
-   csr.io.retire    := !io.ctl.stall // TODO verify this works properly
+   csr.io.retire    := exe_reg_valid && !(io.ctl.stall || io.ctl.exception)
    csr.io.exception := io.ctl.exception
    csr.io.pc        := exe_reg_pc
    exception_target := csr.io.evec

--- a/src/rv32_3stage/dpath.scala
+++ b/src/rv32_3stage/dpath.scala
@@ -244,36 +244,33 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    //**********************************
    // Printout
 
-   val irt_reg = RegInit(0.asUInt(conf.xprlen.W))
-   when (wb_reg_valid) { irt_reg := irt_reg + 1.U }
-
    val debug_wb_pc = Wire(UInt(32.W))
    debug_wb_pc := Mux(RegNext(wb_hazard_stall), 0.U, RegNext(exe_pc))
    val debug_wb_inst = RegNext(Mux((wb_hazard_stall || io.ctl.exe_kill || !exe_valid), BUBBLE, exe_inst))
-   printf("Cyc=%d Op1=[0x%x] Op2=[0x%x] W[%c,%d= 0x%x] [%c,0x%x] %d %c %c PC=(0x%x,0x%x,0x%x) [%x,%d,%d], WB: DASM(%x)\n"
-      , csr.io.time(31,0)
-      , exe_alu_op1
-      , exe_alu_op2
-      , Mux(wb_reg_ctrl.rf_wen, Str("W"), Str("_"))
-      , wb_reg_wbaddr
-      , wb_wbdata
-      , Mux(io.ctl.exception, Str("E"), Str("_"))
-      , io.imem.resp.bits.inst
-      , irt_reg(11,0)
-      , Mux(wb_hazard_stall, Str("H"), Str(" "))  // HAZ -> H
-      , Mux(io.ctl.pc_sel === 1.U, Str("B"),   // Br -> B
-        Mux(io.ctl.pc_sel === 2.U, Str("J"),   // J -> J
-        Mux(io.ctl.pc_sel === 3.U, Str("R"),   // JR -> R
-        Mux(io.ctl.pc_sel === 4.U, Str("X"),   //XPCT -> X
-        Mux(io.ctl.pc_sel === 0.U, Str(" "), Str("?"))))))
-      , io.imem.debug.if_pc(31,0)
-      , exe_pc(31,0)
-      , Mux(RegNext(wb_hazard_stall), 0.U, RegNext(exe_pc(31,0)))
-      , io.imem.debug.if_inst(6,0)
-      , Mux(exe_valid, exe_inst, BUBBLE)(6,0)
-      , debug_wb_inst(6,0)
-      , debug_wb_inst
-      )
+
+   printf("Cyc= %d [%d] pc=[%x] W[r%d=%x][%d] Op1=[r%d][%x] Op2=[r%d][%x] inst=[%x] %c%c%c DASM(%x)\n",
+      csr.io.time(31,0),
+      csr.io.retire,
+      debug_wb_pc,
+      wb_reg_wbaddr,
+      wb_wbdata,
+      wb_reg_ctrl.rf_wen,
+      RegNext(exe_rs1_addr),
+      RegNext(exe_alu_op1),
+      RegNext(exe_rs2_addr),
+      RegNext(exe_alu_op2),
+      debug_wb_inst,
+      MuxCase(Str(" "), Seq(
+         wb_hazard_stall -> Str("H"),
+         io.ctl.exe_kill -> Str("K"))),
+      MuxLookup(io.ctl.pc_sel, Str("?"), Seq(
+         PC_BR -> Str("B"),
+         PC_J -> Str("J"),
+         PC_JR -> Str("R"),
+         PC_EXC -> Str("E"),
+         PC_4 -> Str(" "))),
+      Mux(csr.io.exception, Str("X"), Str(" ")),
+      debug_wb_inst)
 
    // for debugging, print out the commit information.
    // can be compared against the riscv-isa-run Spike ISA simulator's commit logger.

--- a/src/rv32_5stage/dpath.scala
+++ b/src/rv32_5stage/dpath.scala
@@ -52,10 +52,12 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    val if_reg_pc             = RegInit(START_ADDR)
 
    // Instruction Decode State
+   val dec_reg_valid         = RegInit(false.B)
    val dec_reg_inst          = RegInit(BUBBLE)
    val dec_reg_pc            = RegInit(0.asUInt(conf.xprlen.W))
 
    // Execute State
+   val exe_reg_valid         = RegInit(false.B)
    val exe_reg_inst          = RegInit(BUBBLE)
    val exe_reg_pc            = RegInit(0.asUInt(conf.xprlen.W))
    val exe_reg_wbaddr        = Reg(UInt(5.W))
@@ -75,6 +77,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    val exe_reg_ctrl_csr_cmd  = RegInit(CSR.N)
 
    // Memory State
+   val mem_reg_valid         = RegInit(false.B)
    val mem_reg_pc            = Reg(UInt(conf.xprlen.W))
    val mem_reg_inst          = Reg(UInt(conf.xprlen.W))
    val mem_reg_alu_out       = Reg(Bits())
@@ -92,6 +95,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    val mem_reg_ctrl_csr_cmd  = RegInit(CSR.N)
 
    // Writeback State
+   val wb_reg_valid          = RegInit(false.B)
    val wb_reg_wbaddr         = Reg(UInt())
    val wb_reg_wbdata         = Reg(UInt(conf.xprlen.W))
    val wb_reg_ctrl_rf_wen    = RegInit(false.B)
@@ -129,16 +133,19 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
 
    when (io.ctl.pipeline_kill)
    {
+      dec_reg_valid := false.B
       dec_reg_inst := BUBBLE
    }
    .elsewhen (!io.ctl.dec_stall && !io.ctl.full_stall)
    {
       when (io.ctl.if_kill)
       {
+         dec_reg_valid := false.B
          dec_reg_inst := BUBBLE
       }
       .otherwise
       {
+         dec_reg_valid := true.B
          dec_reg_inst := if_inst
       }
 
@@ -245,6 +252,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    {
       // (kill exe stage)
       // insert NOP (bubble) into Execute stage on front-end stall (e.g., hazard clearing)
+      exe_reg_valid         := false.B
       exe_reg_inst          := BUBBLE
       exe_reg_wbaddr        := 0.U
       exe_reg_ctrl_rf_wen   := false.B
@@ -268,6 +276,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
 
       when (io.ctl.dec_kill)
       {
+         exe_reg_valid         := false.B
          exe_reg_inst          := BUBBLE
          exe_reg_wbaddr        := 0.U
          exe_reg_ctrl_rf_wen   := false.B
@@ -278,6 +287,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
       }
       .otherwise
       {
+         exe_reg_valid         := dec_reg_valid
          exe_reg_inst          := dec_reg_inst
          exe_reg_wbaddr        := dec_wbaddr
          exe_reg_ctrl_rf_wen   := io.ctl.rf_wen
@@ -324,13 +334,15 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
 
    when (io.ctl.pipeline_kill)
    {
-      mem_reg_pc            := BUBBLE
+      mem_reg_valid         := false.B
+      mem_reg_inst          := BUBBLE
       mem_reg_ctrl_rf_wen   := false.B
       mem_reg_ctrl_mem_val  := false.B
       mem_reg_ctrl_csr_cmd  := false.B
    }
    .elsewhen (!io.ctl.full_stall)
    {
+      mem_reg_valid         := exe_reg_valid
       mem_reg_pc            := exe_reg_pc
       mem_reg_inst          := exe_reg_inst
       mem_reg_alu_out       := Mux((exe_reg_ctrl_wb_sel === WB_PC4), exe_pc_plus4, exe_alu_out)
@@ -359,7 +371,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    csr.io.rw.wdata := mem_reg_alu_out
    csr.io.rw.cmd   := mem_reg_ctrl_csr_cmd
 
-   csr.io.retire    := !io.ctl.full_stall && !io.ctl.dec_stall
+   csr.io.retire    := wb_reg_valid
    csr.io.exception := io.ctl.mem_exception
    csr.io.pc        := mem_reg_pc
    exception_target := csr.io.evec
@@ -385,12 +397,14 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
 
    when (!io.ctl.full_stall)
    {
+      wb_reg_valid         := mem_reg_valid && !io.ctl.mem_exception
       wb_reg_wbaddr        := mem_reg_wbaddr
       wb_reg_wbdata        := mem_wbdata
       wb_reg_ctrl_rf_wen   := Mux(io.ctl.mem_exception, false.B, mem_reg_ctrl_rf_wen)
    }
    .otherwise
    {
+      wb_reg_valid         := false.B
       wb_reg_ctrl_rf_wen   := false.B
    }
 

--- a/src/rv32_ucode/cpath.scala
+++ b/src/rv32_ucode/cpath.scala
@@ -38,6 +38,7 @@ class CtlToDatIo extends Bundle()
    val upc     = Output(UInt()) // for debugging purposes
    val upc_is_fetch = Output(Bool()) // for debugging purposes
    val exception = Output(Bool())
+   val retire = Output(Bool())
 }
 
 class CpathIo(implicit val conf: SodorConfiguration) extends Bundle()
@@ -144,6 +145,16 @@ class CtlPath(implicit val conf: SodorConfiguration) extends Module
 
    io.ctl.upc := upc_state
    io.ctl.upc_is_fetch := (upc_state === label_target_map("FETCH").U)
+
+   // track whether current instruction caused an exception
+   val en_retire = RegInit(false.B)
+   when (io.ctl.upc_is_fetch) {
+      en_retire := true.B
+   }
+   when (io.ctl.exception) {
+      en_retire := false.B
+   }
+   io.ctl.retire := io.ctl.upc_is_fetch && en_retire
 
    // Memory Interface
    io.mem.req.bits.fcn := Mux(cs.en_mem && cs.mem_wr , M_XWR, M_XRD)

--- a/src/rv32_ucode/dpath.scala
+++ b/src/rv32_ucode/dpath.scala
@@ -141,7 +141,7 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    csr.io.rw.wdata := csr_wdata
    csr.io.rw.cmd   := io.ctl.csr_cmd
    csr_rdata       := csr.io.rw.rdata
-   csr.io.retire    := io.ctl.upc_is_fetch
+   csr.io.retire    := io.ctl.retire
    csr.io.exception := io.ctl.exception
    csr.io.pc        := regfile(PC_IDX) - 4.U
    exception_target := csr.io.evec

--- a/src/rv32_ucode/dpath.scala
+++ b/src/rv32_ucode/dpath.scala
@@ -182,27 +182,24 @@ class DatPath(implicit val conf: SodorConfiguration) extends Module
    // Output Signals to the Memory
    io.mem.req.bits.addr := reg_ma.asUInt()
    io.mem.req.bits.data := bus
-   // Retired Instruction Counter
-   val irt_reg = RegInit(0.asUInt(conf.xprlen.W))
-   when (io.ctl.upc_is_fetch) { irt_reg := irt_reg + 1.U }
 
    // Printout
-   printf("%cCyc= %d (MA=0x%x) %d %c %c RegAddr=%d Bus=0x%x A=0x%x B=0x%x PCReg=( 0x%x ) UPC=%d InstReg=[ 0x%x : DASM(%x) ]\n"
-      , Mux(io.ctl.upc_is_fetch, Str("F"), Str(" "))
-      , csr.io.time(31,0)
-      , reg_ma
-      , io.ctl.reg_sel
-      , Mux(io.ctl.en_mem, Str("E"), Str(" "))
-      , Mux(io.ctl.exception, Str("X"), Str(" "))
-      , reg_addr
-      , bus
-      , reg_a
-      , reg_b
-      , regfile(PC_IDX) // this is the PC register
-      , io.ctl.upc
-      , ir
-      , ir
-      )
+   printf("Cyc= %d [%d] PCReg=[%x] uPC=[%x] Bus=[%x] RegSel=[%d] RegAddr=[%d] A=[%x] B=[%x] MA=[%x] InstReg=[%x] %c%c%c DASM(%x)\n",
+      csr.io.time(31,0),
+      csr.io.retire,
+      regfile(PC_IDX),
+      io.ctl.upc,
+      bus,
+      io.ctl.reg_sel,
+      reg_addr,
+      reg_a,
+      reg_b,
+      reg_ma,
+      ir,
+      Mux(io.ctl.upc_is_fetch, Str("F"), Str(" ")),
+      Mux(io.ctl.en_mem, Str("M"), Str(" ")),
+      Mux(io.ctl.exception, Str("X"), Str(" ")),
+      ir)
 
 }
 


### PR DESCRIPTION
This makes the `report-cpi` and `report-stats` targets functional again.

You may recognize the `tracer.py` script from Lab 1, slightly enhanced to also work with the `rv32_ucode` design by relying on a retirement flag instead of the instruction bits to detect a bubble.  Most significantly, a common log format that closely resembles Rocket has been imposed across all pipelined cores:

```
Cyc=         35 [1] pc=[8000007c] W[r 5=0001e000][1] Op1=[r 3][00000000] Op2=[r 0][0001e000] inst=[0001e2b7]     lui     t0, 0x1e
```

`rv32_3stage` and `rv32_5stage` now log instructions from the WB stage instead of EXE, which more accurately reflects commit and highlights differences in pipelining more distinctly.

This also fixes the `instret` counter logic - not all pipeline bubbles and exceptions were properly excluded.