### PR TITLE
Fix off-by-one error with uaddr bitwidth calculation

### DIFF
--- a/src/main/scala/rv32_ucode/microcodecompiler.scala
+++ b/src/main/scala/rv32_ucode/microcodecompiler.scala
@@ -112,11 +112,12 @@ object MicrocodeCompiler
             case Signals(code,str) => uaddr += 1
          }
       }
+      val label_sz = log2Ceil(uaddr)
       println("Label Map " + label_map)
-      println("  MicroROM size    : " + (uaddr-1) + " lines")
-      println("  Bitwidth of uaddr: " + log2Ceil(uaddr-1) + " bits")
+      println("  MicroROM size    : " + uaddr + " lines")
+      println("  Bitwidth of uaddr: " + label_sz + " bits")
       println("")
-      return (label_map, log2Ceil(uaddr-1))
+      return (label_map, label_sz)
    }
 
 


### PR DESCRIPTION
The number of microinstructions in the ROM is given by `uaddr`, not `uaddr-1`.  This causes the uPC and jump targets to have an insufficient bitwidth if the ROM contains exactly `2**n + 1` rows - e.g., if there are 5 microinstructions, the width should be `log2Ceil(5) = 3`, not `log2Ceil(4) = 2`.