### PR TITLE
remove objectmodule

### DIFF
--- a/src/main/scala/common/master_adapter.scala
+++ b/src/main/scala/common/master_adapter.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalTreeNode}
+
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.subsystem.{RocketCrossingParams}
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/common/scratchpad_adapter.scala
+++ b/src/main/scala/common/scratchpad_adapter.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.rocket._
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.model.OMSRAM
+
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._

--- a/src/main/scala/common/sodor_internal_tile.scala
+++ b/src/main/scala/common/sodor_internal_tile.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalTreeNode}
+
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.subsystem.{RocketCrossingParams}
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/common/sodor_tile.scala
+++ b/src/main/scala/common/sodor_tile.scala
@@ -7,7 +7,6 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalTreeNode}
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.subsystem.{RocketCrossingParams}
 import freechips.rocketchip.tilelink._


### PR DESCRIPTION
This is needed for RC bumping after chipsalliance/rocket-chip#2967 get merged. 